### PR TITLE
node() --> pair() in text, to match example code

### DIFF
--- a/_posts/2015-02-13-functional-quantum-electrodynamics.md
+++ b/_posts/2015-02-13-functional-quantum-electrodynamics.md
@@ -207,7 +207,7 @@ latin(second)
   //=> "secundus"
 {% endhighlight %}
 
-It works! Now what is this `node` function? If we change the names to `x`, `y`, and `z`, we get: `(x) => (y) => (z) => z(x)(y)`. That's the V combinator, the Vireo! So we can write:
+It works! Now what is this `pair` function? If we change the names to `x`, `y`, and `z`, we get: `(x) => (y) => (z) => z(x)(y)`. That's the V combinator, the Vireo! So we can write:
 
 {% highlight javascript %}
 const first = K,


### PR DESCRIPTION
At the point in the text where we're asking "what is this `node` function?", all of the recent code examples have called the function `pair` instead.
