### PR TITLE
Better error in example code

### DIFF
--- a/_posts/2015-02-13-functional-quantum-electrodynamics.md
+++ b/_posts/2015-02-13-functional-quantum-electrodynamics.md
@@ -380,7 +380,7 @@ const first = (list) => list(
   );
       
 const rest = (list) => list(
-    () => "ERROR: Can't take first of an empty list",
+    () => "ERROR: Can't take rest of an empty list",
     (aPair) => aPair(pairRest)
   );
 


### PR DESCRIPTION
`rest` should be talking about itself, not about `first`. I don't know why this tool keeps monkeying with the last line in the file.
