### PR TITLE
Update 2015-03-12-symmetry.md

### DIFF
--- a/_posts/2015-03-12-symmetry.md
+++ b/_posts/2015-03-12-symmetry.md
@@ -170,10 +170,10 @@ const requiresFinite = (fn) =>
   
 const plusOne = x => x + 1;
 
-plus1(1)
+plusOne(1)
   //=> 2
   
-plus1([])
+plusOne([])
   //=> 1 WTF!?
   
 const safePlusOne = requiresFinite(plusOne);


### PR DESCRIPTION
minor typo in code example

"const plusOne" declared and used as "plus1"

(great articles! thanks)