### PR TITLE
Fixed typo in JS code

### DIFF
--- a/_posts/2016-12-15-what-higher-order-functions-can-teach-us-about-libraries-and-frameworks.md
+++ b/_posts/2016-12-15-what-higher-order-functions-can-teach-us-about-libraries-and-frameworks.md
@@ -379,7 +379,7 @@ const bisect = (list) => [
     list.slice(0, list.length / 2),
     list.slice(list.length / 2)
   ];
-const mergeLeftAndRight({ left: list1, right: list2 }) => merge({ list1, list2 });
+const mergeLeftAndRight = ({ left: list1, right: list2 }) => merge({ list1, list2 });
 const mergeBisected = ([list1, list2]) => merge({ list1, list2 });
 ```
 


### PR DESCRIPTION
Added a missing equals sign in the definition of mergeLeftAndRight.

P.S. A big think you for all the articles over the years! I've learned a lot from you.