### PR TITLE
Fix typo

### DIFF
--- a/_posts/2016-12-27-recursive-data-structures.md
+++ b/_posts/2016-12-27-recursive-data-structures.md
@@ -123,7 +123,7 @@ By rotating each smaller square, it becomes:
 ⚪️⚪️ ⚫️⚫️
 ```
 
-And we rotate all for squares to finish with:
+And we rotate all four squares to finish with:
 
 ```
 ⚪️⚪️ ⚪️⚪️


### PR DESCRIPTION
Fixes a small typo. "for" -> "four".

Great article 😄 